### PR TITLE
Feature/load cafes from mongodb

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const logger = require('morgan');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 
+// Routes
 const cafeAPI = require('./routes/api');
 const index = require('./routes/index');
 const users = require('./routes/users');
@@ -18,6 +19,9 @@ const cafe = require('./routes/cafe');
 const privacyPolicy = require('./routes/privacy-policy');
 const aboutUs = require('./routes/about-us');
 const careers = require('./routes/careers');
+
+// Model Classes
+const Cafe = require('./models/cafe');
 
 //Use `.hbs` for extensions and find partials in `views/partials`.
 const app = express();
@@ -78,40 +82,10 @@ app.use((err, req, res, next) => {
     res.render('error');
 });
 
-//TODO: Remove when we can load this from the database
-app.locals.cafes = [
-    {
-        name: 'An Bialann',
-        urlTag: 'an-bialann'
-    },
-    {
-        name: 'Smokeys',
-        urlTag: 'smokeys'
-    },
-    {
-        name: 'Sult',
-        urlTag: 'sult'
-    },
-    {
-        name: 'Friars',
-        urlTag: 'friars'
-    },
-    {
-        name: 'Zinc',
-        urlTag: 'zinc'
-    },
-    {
-        name: 'Cloud Cafe',
-        urlTag: 'cloud-cafe'
-    },
-    {
-        name: 'The Wall',
-        urlTag: 'the-wall'
-    },
-    {
-        name: 'Caife na Gaeilge',
-        urlTag: 'caife-na-gaeilge'
-    }
-];
+// cache the cafes in the app.locals.cafes
+Cafe.find({}, (err, res) =>{
+    console.log("Cached %d cafe's in the app.locals", res.length);
+    app.locals.cafes = res;
+});
 
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ const logger = require('morgan');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 
-// Routes
+//Routes
 const cafeAPI = require('./routes/api');
 const index = require('./routes/index');
 const users = require('./routes/users');
@@ -20,7 +20,7 @@ const privacyPolicy = require('./routes/privacy-policy');
 const aboutUs = require('./routes/about-us');
 const careers = require('./routes/careers');
 
-// Model Classes
+//Model Classes
 const Cafe = require('./models/cafe');
 
 //Use `.hbs` for extensions and find partials in `views/partials`.
@@ -82,9 +82,9 @@ app.use((err, req, res, next) => {
     res.render('error');
 });
 
-// cache the cafes in the app.locals.cafes
-Cafe.find({}, (err, res) =>{
-    console.log("Cached %d cafe's in the app.locals", res.length);
+//cache the cafes in the app.locals.cafes
+Cafe.find({}, (err, res) => {
+    console.log('Cached %d cafe\'s in the app.locals', res.length);
     app.locals.cafes = res;
 });
 

--- a/data/cafes.js
+++ b/data/cafes.js
@@ -37,17 +37,19 @@ const cafes = [
 ];
 
 function add_cafes() {
-    console.log('[Cafes]');
+    //clear out entries, add default data
+    return Cafe.deleteMany({}).then(
+        (res) => {
+            console.log('[Cafes]');
+            console.log('Removed existing cafes, %s', res);
+            for(let i = 0; i < cafes.length; i++) {
+                console.log(`    * ${cafes[i].name}`);
+                new Cafe(cafes[i]).save();
+            }
 
-    //clear out entries
-    Cafe.deleteMany({}).exec();
-
-    for(let i = 0; i < cafes.length; i++) {
-        console.log(`    * ${cafes[i].name}`);
-        new Cafe(cafes[i]).save();
-    }
-
-    console.log();
+            console.log();
+        }
+    );
 }
 
 module.exports = add_cafes;

--- a/data/populate-db.js
+++ b/data/populate-db.js
@@ -10,12 +10,9 @@ console.log(`   mongodb://${mongoose.connection.host}:${mongoose.connection.port
 console.log('   Clearing out old entries and inserting default data.\n');
 
 //dropDb();
-populateUsers();
-populateCafes();
-
-//TODO: remove this and promisify
-//mongodbConnection.disconnect();
-setTimeout(() => {
-    console.log('[+] Finsihed - Press Ctrl+c to exit');
-},
-10000);
+populateUsers()
+.then(populateCafes)
+.then(()=>{
+    console.log('[+] Finished adding data to model.');
+    mongodbConnection.disconnect();
+});

--- a/data/users.js
+++ b/data/users.js
@@ -2,30 +2,34 @@ const mongoose = require('mongoose');
 const User = require('../models/user.js');
 
 function add_users() {
-    console.log('[Users]');
 
-    User.deleteMany({}).exec();
+    return User.deleteMany({}).then(
+        (res) => {
+            console.log('\n[Users]');
+            console.log('Removed existing users, %s', res);
 
-    const admin = new User({
-        email: 'admin'
-    });
-    admin.password_hash = admin.generateHash('admin');
-    admin.save();
-    console.log('   * admin');
+            const admin = new User({
+                email: 'admin'
+            });
+            admin.password_hash = admin.generateHash('admin');
+            admin.save();
+            console.log('   * admin');
 
-    const cafe = new User({
-        email: 'cafe'
-    });
-    cafe.password_hash = admin.generateHash('cafe');
-    cafe.save();
-    console.log('   * cafe');
+            const cafe = new User({
+                email: 'cafe'
+            });
+            cafe.password_hash = admin.generateHash('cafe');
+            cafe.save();
+            console.log('   * cafe');
 
-    const test = new User({
-        email: 'test'
-    });
-    test.password_hash = test.generateHash('test');
-    test.save();
-    console.log('   * test\n');
+            const test = new User({
+                email: 'test'
+            });
+            test.password_hash = test.generateHash('test');
+            test.save();
+            console.log('   * test\n');
+        }
+    );
 }
 
 module.exports = add_users;

--- a/models/cafe.js
+++ b/models/cafe.js
@@ -7,8 +7,8 @@ require('./util');
 
 const cafeSchema = new mongoose.Schema({
     name: { type: String },
-    urlTag: { type: String },
-    location: { type: String }
+    location: { type: String },
+    urlTag: { type: String }
 });
 
 module.exports = mongoose.model('unibites-cafes', cafeSchema);

--- a/models/cafe.js
+++ b/models/cafe.js
@@ -7,6 +7,7 @@ require('./util');
 
 const cafeSchema = new mongoose.Schema({
     name: { type: String },
+    urlTag: { type: String },
     location: { type: String }
 });
 

--- a/routes/cafe.js
+++ b/routes/cafe.js
@@ -13,6 +13,8 @@ router.get('/:cafename', (req, res, next) => {
 
     const cafes = req.app.locals.cafes;
 
+    console.log(JSON.stringify(req.app.locals));
+
     for(let i = 0; i < cafes.length; i++) {
         if(cafes[i].urlTag == cafeTag) {
             cafeTitle = cafes[i].name;

--- a/specs/ui-tests/cafe.spec.js
+++ b/specs/ui-tests/cafe.spec.js
@@ -1,0 +1,23 @@
+//spec.js
+describe('uni-bites cafe tests', () => {
+    const until = protractor.ExpectedConditions;
+  
+    beforeEach(() => {
+        browser.waitForAngularEnabled(false);
+        browser.get(`${browser.params.baseUrl}/cafe/an-bialann`); //rework to page pattern see : http://blog.scottlogic.com/2015/11/06/ProtractorForBeginnersPart1.html
+    });
+
+    it('should have the correct title', () => {
+        expect(browser.getTitle()).toEqual('An Bialann | Uni-Bites');
+    });
+
+    it('should contain the cafe name', () => {
+        let cafeHeader = element(by.css("h1"));
+        expect(cafeHeader).not.toBeNull();
+        
+        expect(cafeHeader.getText()).toBe('An Bialann');
+    });
+
+    afterEach(() => {
+    });
+});

--- a/specs/ui-tests/cafe.spec.js
+++ b/specs/ui-tests/cafe.spec.js
@@ -12,7 +12,7 @@ describe('uni-bites cafe tests', () => {
     });
 
     it('should contain the cafe name', () => {
-        let cafeHeader = element(by.css("h1"));
+        const cafeHeader = element(by.css('h1'));
         expect(cafeHeader).not.toBeNull();
         
         expect(cafeHeader.getText()).toBe('An Bialann');

--- a/specs/ui-tests/homepage.spec.js
+++ b/specs/ui-tests/homepage.spec.js
@@ -3,39 +3,37 @@ describe('uni-bites homepage tests', () => {
     const until = protractor.ExpectedConditions;
 
     let ddCafes;
-    let ddCafesMenu; 
+    let ddCafesMenu;
   
     beforeEach(() => {
         browser.waitForAngularEnabled(false);
         browser.get(`${browser.params.baseUrl}`); //rework to page pattern see : http://blog.scottlogic.com/2015/11/06/ProtractorForBeginnersPart1.html
-
-
     });
 
-    // home page dropdown should 
+    //home page dropdown should
     it('should have the correct title', () => {
         expect(browser.getTitle()).toEqual('uni-bites');
     });
 
-    // Search
-    // it('should do some search stuff when the search button is clicked ', () => {
-    //     ddCafes.click();
-    // });
+    //Search
+    //it('should do some search stuff when the search button is clicked ', () => {
+    //ddCafes.click();
+    //});
 
-    // navigation
+    //navigation
     it('should display the cafes menu when the button is clicked', () => {
-        let ddCafes = element(by.css("a[class='dropdown-toggle']"));
-        let ddCafesMenu = element(by.css("ul[class='dropdown-menu']"));
+        const ddCafes = element(by.css('a[class=\'dropdown-toggle\']'));
+        const ddCafesMenu = element(by.css('ul[class=\'dropdown-menu\']'));
 
         expect(ddCafes).not.toBeNull();
         expect(ddCafesMenu).not.toBeNull();
 
         ddCafes.click();
-        expect(ddCafesMenu.isPresent()).toBeTruthy("cafemenu not shown");
+        expect(ddCafesMenu.isPresent()).toBeTruthy('cafemenu not shown');
     });
 
     it('should go to the about us page when the about us button is clicked', () => {
-        let btnAboutUs = element(by.linkText("About Us"));
+        const btnAboutUs = element(by.linkText('About Us'));
 
         expect(btnAboutUs).not.toBeNull();
 
@@ -45,7 +43,7 @@ describe('uni-bites homepage tests', () => {
     });
 
     it('should go to the about us page when the about us button is clicked', () => {
-        let btnLoginRegister = element(by.linkText("Login/Register"));
+        const btnLoginRegister = element(by.linkText('Login/Register'));
 
         expect(btnLoginRegister).not.toBeNull();
 

--- a/specs/ui-tests/homepage.spec.js
+++ b/specs/ui-tests/homepage.spec.js
@@ -1,0 +1,59 @@
+//spec.js
+describe('uni-bites homepage tests', () => {
+    const until = protractor.ExpectedConditions;
+
+    let ddCafes;
+    let ddCafesMenu; 
+  
+    beforeEach(() => {
+        browser.waitForAngularEnabled(false);
+        browser.get(`${browser.params.baseUrl}`); //rework to page pattern see : http://blog.scottlogic.com/2015/11/06/ProtractorForBeginnersPart1.html
+
+
+    });
+
+    // home page dropdown should 
+    it('should have the correct title', () => {
+        expect(browser.getTitle()).toEqual('uni-bites');
+    });
+
+    // Search
+    // it('should do some search stuff when the search button is clicked ', () => {
+    //     ddCafes.click();
+    // });
+
+    // navigation
+    it('should display the cafes menu when the button is clicked', () => {
+        let ddCafes = element(by.css("a[class='dropdown-toggle']"));
+        let ddCafesMenu = element(by.css("ul[class='dropdown-menu']"));
+
+        expect(ddCafes).not.toBeNull();
+        expect(ddCafesMenu).not.toBeNull();
+
+        ddCafes.click();
+        expect(ddCafesMenu.isPresent()).toBeTruthy("cafemenu not shown");
+    });
+
+    it('should go to the about us page when the about us button is clicked', () => {
+        let btnAboutUs = element(by.linkText("About Us"));
+
+        expect(btnAboutUs).not.toBeNull();
+
+        btnAboutUs.click();
+
+        browser.wait(until.urlContains('/about-us'), 5000);
+    });
+
+    it('should go to the about us page when the about us button is clicked', () => {
+        let btnLoginRegister = element(by.linkText("Login/Register"));
+
+        expect(btnLoginRegister).not.toBeNull();
+
+        btnLoginRegister.click();
+
+        browser.wait(until.urlContains('/login'), 5000);
+    });
+
+    afterEach(() => {
+    });
+});


### PR DESCRIPTION
* Cafes loaded from database, cafe's in app cache loaded on startup from mongodb.
* Fixes to `npm run populate-db`, more reliable, uses promises for asynchronous db operations _(prevents odd situations like inserting before the delete has run..)_
* Initial specs for home page and cafe page.

This should close #48 and leave the project in a good state for #32 , where we have a solid method to generate and import test data every time.

It would be worth looking into any in memory features in mongodb to go with #32. 