### PR TITLE
Screenshots of failing ut-tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,11 @@
     "test:once": "webdriver-manager update",
     "test:web-driver": "./node_modules/.bin/webdriver-manager start",
     "test:servers": "concurrently \"npm start\" \"npm run test:web-driver\"",
-    
     "test:api": "mocha ./specs/api-tests/cafe.spec.js",
     "lint": "npm run lint:client; npm run lint:server",
     "lint:client": "eslint -c eslintrc.client.json --fix --ignore-pattern '*.min.js' public/javascripts/*.js",
     "lint:server": "eslint -c eslintrc.server.json --fix  specs/ui-tests/*.js models/*.js routes/*.js data/*.js bin/www ./*.js",
     "lint:reports": "eslint --fix-dry-run --no-color -o eslint.report.client.txt -c eslintrc.client.json --fix-dry-run --ignore-pattern '*.min.js' public/javascripts/*.js;eslint --fix-dry-run --no-color -o eslint.report.server.txt -c eslintrc.server.json specs/ui-tests/*.js models/*.js routes/*.js data/*.js bin/www ./*.js;echo $'\nReports written to: \n * eslint.report.client.txt\n * eslint.report.server.txt'",
-    
     "docs": "gitbook serve docs",
     "docs:once": "gitbook install docs"
   },
@@ -27,7 +25,6 @@
     "cookie-parser": "^1.4.3",
     "debug": "^2.6.9",
     "express": "^4.15.5",
-    "express-handlebars": "^3.0.0",
     "express-hbs": "^1.0.4",
     "hbs": "^4.0.1",
     "jsonwebtoken": "^8.1.1",
@@ -47,6 +44,7 @@
     "jasmine": "^3.0.0",
     "mocha": "^5.0.1",
     "protractor": "^5.3.0",
+    "protractor-jasmine2-screenshot-reporter": "^0.5.0",
     "supertest": "^3.0.0"
   }
 }

--- a/specs/ui-tests/conf.js
+++ b/specs/ui-tests/conf.js
@@ -1,3 +1,13 @@
+const HtmlScreenshotReporter = require('protractor-jasmine2-screenshot-reporter');
+const path = require('path');
+
+var reporter = new HtmlScreenshotReporter({
+    dest: `${__dirname}/report`,
+    filename: 'test-report.html',
+    cleanDestination: true,
+    captureOnlyFailedSpecs: true
+});
+
 exports.config = {
     framework: 'jasmine',
     seleniumAddress: 'http://localhost:4444/wd/hub',
@@ -7,8 +17,27 @@ exports.config = {
     },
     stackTrace: false,
 
+    // Setup the report before any tests start
+    beforeLaunch: function() {
+        return new Promise(function(resolve){
+            reporter.beforeLaunch(resolve);
+        });
+    },
+
+    // Assign the test reporter to each running instance
+    onPrepare: function() {
+        jasmine.getEnv().addReporter(reporter);
+    },
+
+    // Close the report after all tests finish
+    afterLaunch: function(exitCode) {
+        return new Promise(function(resolve){
+            reporter.afterLaunch(resolve.bind(this, exitCode));
+        });
+    },
+
     params: {
-        baseUrl: 'http://localhost:8604', //TODO: Parameterise this
+        baseUrl: 'http://localhost:8604', //TODO: Pull this from  env file.. 
         validUser: {
             name: 'test',
             password: 'test'


### PR DESCRIPTION
This generates a report that adds screenshots of all failing ui-tests to  a specs/ui-test/report sub directory every time 'npm run test' is run.

This implements #62 

